### PR TITLE
Breaking change - EVENT method

### DIFF
--- a/Framework/Expectations.lua
+++ b/Framework/Expectations.lua
@@ -1,26 +1,38 @@
+--- Expect function input types. To replace `cc.expect` by returning a value instead of throwing an error.
+---@param n integer Argument position.
+---@param val any The input value.
+---@param ... string The types to allow. Argument can be any of the input values.
+---@return boolean satisfied If the expectation is satisfied.
+---@return string error The error, if expectation fails.
 local function expect(n, val, ...)
   local args = table.pack(...)
   local t = type(val)
 
   for i = 1, args.n do
     if t == args[i] then
-      return true
+      return true, ""
     end
   end
 
   return false,
-         string.format(
-           "Bad argument to test function #%d: Expected %s, got %s.",
-           n,
-           table.concat(
-             args,
-             " or "
-           ),
-           t
-         )
+      string.format(
+        "Bad argument to test function #%d: Expected %s, got %s.",
+        n,
+        table.concat(
+          args,
+          " or "
+        ),
+        t
+      )
 end
 
 local t_eq_error = "Tables are not equal."
+--- Check if a table is equal to another table
+---@param a table Table A
+---@param b table Table B
+---@param noflip boolean? Only check one direction if true.
+---@return boolean equal If the table is equal.
+---@return string string The error if the tables are not equal.
 local function t_eq(a, b, noflip)
   if type(a) ~= "table" or type(b) ~= "table" then return false, t_eq_error end
   for k, v in pairs(a) do
@@ -38,18 +50,30 @@ local function t_eq(a, b, noflip)
   return true, ""
 end
 
+---@class Expectations
 local M = {}
 
-function M.EVENT(f, event, timeout, ...)
+--- Expect that an event should occur.
+---@param f function The function to run, the event should occur sometime during this function running.
+---@param timeout integer? If the function runs longer than this and no event occurs, fail.
+---@param event string The event name to listen for.
+---@param ... any The event arguments to test for.
+---@return boolean satisfied If the expectation was satisfied.
+---@return string? error If there was an error, return the error.
+function M.EVENT(f, timeout, event, ...)
+  local event_args = table.pack(...)
+  if event_args[1] ~= event then
+    table.insert(event_args, 1, event)
+  end
   local ok, e = expect(1, f, "function")
-    if not ok then return false, e end
+  if not ok then return false, e end
   ok, e = expect(2, event, "string")
-    if not ok then return false, e end
+  if not ok then return false, e end
   ok, e = expect(3, timeout, "number", "nil")
-    if not ok then return false, e end
+  if not ok then return false, e end
 
-  ok, e = pcall(f, ...)
-    if not ok then error(e, 0) end
+  ok, e = pcall(f)
+  if not ok then error(e, 0) end
 
   local tmr = os.startTimer(timeout or 0.25)
   while true do
@@ -57,37 +81,78 @@ function M.EVENT(f, event, timeout, ...)
     if ev[1] == "timer" and ev[2] == tmr then
       return false, string.format("Timed out before receiving event '%s'.", event)
     elseif ev[1] == event then
+      for i = 1, event_args.n do
+        local is_equal, err = M.EQ(event_args[i], ev[i])
+        if not is_equal then
+          return false, string.format("Event received, but argument %d is unexpected: %s", i, err)
+        end
+      end
       return true, ""
     end
   end
 end
 
+--- Compare two values for equality.
+---@param a any Value A.
+---@param b any Value B.
+---@return boolean satisfied If the values are equal.
+---@return string error If the values are unequal.
 function M.EQ(a, b)
   return a == b, string.format("Values %s and %s are unequal.", tostring(a), tostring(b))
 end
 
+--- Compare two values for inequality.
+---@param a any Value A.
+---@param b any Value B.
+---@return boolean satisfied If the values are unequal.
+---@return string error If the values are equal.
 function M.UEQ(a, b)
   return a ~= b, string.format("Values %s and %s are equal.", tostring(a), tostring(b))
 end
 
+--- Check if value A is greater than value B.
+---@param a any Value A.
+---@param b any Value B.
+---@return boolean satisfied If A > B.
+---@return string error If A <= B.
 function M.GT(a, b)
   return a > b, string.format("Value %s is not greater than %s.", tostring(a), tostring(b))
 end
 
+--- Check if value A is less than value B.
+---@param a any Value A.
+---@param b any Value B.
+---@return boolean satisfied If A < B.
+---@return string error If A >= B.
 function M.LT(a, b)
   return a < b, string.format("Value %s is not less than %s.", tostring(a), tostring(b))
 end
 
+--- Check if value A is greater than or equal to value B.
+---@param a any Value A.
+---@param b any Value B.
+---@return boolean satisfied If A >= B.
+---@return string error If A < B.
 function M.GTE(a, b)
   return a >= b, string.format("Value %s is not greater than or equal to %s.", tostring(a), tostring(b))
 end
 
+--- Check if value A is less than or equal to value B.
+---@param a any Value A.
+---@param b any Value B.
+---@return boolean satisfied If A <= B.
+---@return string error If A > B.
 function M.LTE(a, b)
   return a <= b, string.format("Value %s is not less than or equal to %s.", tostring(a), tostring(b))
 end
 
+--- Check if a table is equal to another table, comparing recursively.
+---@param a table Table A.
+---@param b table Table B.
+---@return boolean satisfied If both tables have equal keys and values.
+---@return string error If the tables are not equal.
 function M.DEEP_TABLE_EQ(a, b)
-  local mt = getmetatable(a)
+  local mt = getmetatable(a) ---@type table?
   if mt and mt.__pairs then
     local ok = pcall(pairs, a)
     if not ok then
@@ -103,30 +168,47 @@ function M.DEEP_TABLE_EQ(a, b)
     end
   end
   local ok, e = expect(1, a, "table")
-    if not ok then return false, e end
+  if not ok then return false, e end
   local ok2, e2 = expect(2, b, "table")
-    if not ok2 then return false, e2 end
+  if not ok2 then return false, e2 end
   return t_eq(a, b)
 end
 
+--- Compare that two float values are "close enough" to be equal, since floats don't like to play nice with equality checks sometimes.
+---@param a number Number A.
+---@param b number Number B.
+---@param range number Maximum offset between the two values allowed.
+---@return boolean satisfied If the floats are "close enough".
+---@return string error If the floats were not close enough.
 function M.FLOAT_EQ(a, b, range)
   local ok, e = expect(3, range, "number", "nil")
-    if not ok then return false, e end
+  if not ok then return false, e end
   range = range or 0.000000000001
-  return a >= b - range and a <= b + range, string.format("Value %s is not within %f of %s", tostring(a), range, tostring(b))
+  return a >= b - range and a <= b + range,
+      string.format("Value %s is not within %f of %s", tostring(a), range, tostring(b))
 end
 
+--- Expect that a value is of type 't'.
+---@param a any The value to test.
+---@param t string The type to test for.
+---@return boolean satisfied If the type of the value was the type expected.
+---@return string error If the type of the value was not the type expected.
 function M.TYPE(a, t)
   local ok, e = expect(2, t, "string")
-    if not ok then return false, e end
+  if not ok then return false, e end
   return type(a) == t, string.format("Value %s is not of type %s.", tostring(a), t)
 end
 
+--- Expect that a value is one of the given types.
+---@param a any The value to test.
+---@param ... string The types to test for.
+---@return boolean satisfied If the type of the value was expected.
+---@return string error If the type of the value was not expected.
 function M.TYPES(a, ...)
   local types = table.pack(...)
   for i = 1, types.n do
     local ok, e = expect(i + 1, types[i], "string")
-      if not ok then return false, e end
+    if not ok then return false, e end
 
     if type(a) ~= types[i] then
       return false, string.format("Value %s is not of type %s.", tostring(a), table.concat(types, " or "))
@@ -136,42 +218,74 @@ function M.TYPES(a, ...)
   return true, ""
 end
 
+--- Expect a value to be true.
+---@param a boolean The value.
+---@return boolean satisfied If the value is true.
+---@return string error If the value is not true.
 function M.TRUE(a)
   return a == true, string.format("Value %s is not 'true'.", tostring(a))
 end
 
+--- Expect a value to be false.
+---@param a boolean The value.
+---@return boolean satisfied If the value is false.
+---@return string error If the value is not false.
 function M.FALSE(a)
   return a == false, string.format("Value %s is not 'false'.", tostring(a))
 end
 
+--- Expect a value to be truthy.
+---@param a any The value.
+---@return boolean satisfied If the value is truthy.
+---@return string error If the value is not truthy.
 function M.TRUTHY(a)
   return not not a, string.format("Value %s is not truthy.", tostring(a))
 end
 
+--- Expect a value to be falsey.
+---@param a false? The value.
+---@return boolean satisfied If the value is falsey.
+---@return string error If the value is not falsey.
 function M.FALSEY(a)
   return not a, string.format("Value %s is not falsey.", tostring(a))
 end
 
+--- Expect that a function will throw any error with the given arguments.
+---@param f function The function to test.
+---@param ... any The arguments to give to the function.
+---@return boolean satisfied If the function threw any error.
+---@return string error If the function did not throw an error.
 function M.THROW_ANY_ERROR(f, ...)
   local ok, e = expect(1, f, "function")
   if not ok then return false, e end
-  local ok, err = pcall(f, ...)
-  return not ok, "Function did not throw an error."
+  local ok2 = pcall(f, ...)
+  return not ok2, "Function did not throw an error."
 end
 
+--- Expect that a function will throw an error that follows a specific pattern, given specific arguments.
+---@param f function The function to test.
+---@param m string The match pattern to use.
+---@param ... any The arguments to give to the function.
+---@return boolean satisfied If the function threw an error that matched the given pattern.
+---@return string error If the function did not throw an error, or it did not match the pattern.
 function M.THROW_MATCHED_ERROR(f, m, ...)
   local ok, e = expect(1, f, "function")
-    if not ok then return false, e end
+  if not ok then return false, e end
   local ok2, e2 = expect(2, m, "string")
-    if not ok2 then return false, e2 end
+  if not ok2 then return false, e2 end
 
-  local ok, err = pcall(f, ...)
-  if ok then return false, "Function did not throw an error." end
+  local ok3, err = pcall(f, ...)
+  if ok3 then return false, "Function did not throw an error." end
 
   local match = string.match(err, m)
   return match and true or false, string.format("Error '%s' does not match pattern '%s'.", err, m)
 end
 
+--- Expect that a function will NOT throw any error, given specific arguments.
+---@param f function The function to test.
+---@param ... any The arguments to give to the function.
+---@return boolean satisfied If the function did not throw an error.
+---@return string error If the function threw an error.
 function M.NO_THROW(f, ...)
   local ok, e = expect(1, f, "function")
   if not ok then return false, e end

--- a/Framework/init.lua
+++ b/Framework/init.lua
@@ -1,4 +1,3 @@
-
 -- Calculate the path to self for module requiring.
 local modulesPath = ...
 
@@ -16,7 +15,9 @@ for i = #modulesPath, 1, -1 do
   end
 end
 
+---@class test
 
+---@class suite
 
 local module = {
   loaded = {},
@@ -27,7 +28,8 @@ local module = {
 local function badModule(module, versionMinimum)
   local dir = fs.getDir(shell.getRunningProgram())
   term.setTextColor(colors.orange)
-  print(string.format("Module '%s' does not exist on pre-%s minecraft versions. This test framework will not work on your version of minecraft without doing the following:", module, versionMinimum))
+  print(string.format("Module '%s' does not exist on pre-%s minecraft versions. This test framework will not work on your version of minecraft without doing the following:"
+    , module, versionMinimum))
   print()
   print("1.", "Go to https://github.com/Squiddev-CC/CC-Tweaked")
   print("2.", string.format("Click 'Go To File', and search for '%s.lua'.", module:gsub("%.", "/")))
@@ -53,12 +55,11 @@ local dummyTerminate = "DUMMY"
 local verbose = false
 local hasVPrinted = false
 
-_G.DISABLED = {} -- global for disabled test
+_G.DISABLED = {} --- global for disabled tests
 
-function _G.DUMMY_TERMINATE() -- global for terminating but not killing the program.
+function _G.DUMMY_TERMINATE() --- Terminate but do not kill the test program.
   return "terminate", dummyTerminate
 end
-
 
 function _G.verbosePrint(...)
   if verbose then
@@ -70,12 +71,17 @@ function _G.verbosePrint(...)
   end
 end
 
--- This functions builds the info line for the current test, ie:
--- [ RUN ] testName
--- [ FAIL] testName
--- [ERROR] testName
--- ... so on
--- generates blit line bg and fg colors as well
+--- This functions builds the info line for the current test, ie:
+--- [ RUN ] testName
+--- [ FAIL] testName
+--- [ERROR] testName
+--- ... so on
+--- generates blit line bg and fg colors as well
+---@param name string The name of the info line.
+---@param status number The status of the test.
+---@return string text The status text.
+---@return string foreground The blit foreground.
+---@return string background The blit background.
 local function buildInfoLine(name, status)
   expect(1, name, "string")
   expect(2, status, "number")
@@ -115,11 +121,12 @@ local function buildInfoLine(name, status)
   end
 
   return string.format(formatInfo, statusString, name),
-         string.format(formatFG, statusFG, string.rep('a', #name)),
-         string.format(formatBG, statusBG, string.rep('f', #name))
+      string.format(formatFG, statusFG, string.rep('a', #name)),
+      string.format(formatBG, statusBG, string.rep('f', #name))
 end
 
--- write the info about a test.
+--- write the info about a test.
+---@param t test The test to write information for.
 local function writeInfo(t)
   local xSize = term.getSize()
   local x, y = term.getCursorPos()
@@ -130,7 +137,8 @@ local function writeInfo(t)
   term.blit(buildInfoLine(t.name, t.status))
 end
 
--- if the test failed or errored, print the reason, otherwise just draw a newline
+--- if the test failed or errored, print the reason, otherwise just draw a newline
+---@param t test The test to print error reason for.
 local function finishTest(t)
   print()
   if t.status == Test.STATUS.FAIL then
@@ -146,6 +154,10 @@ local function finishTest(t)
   end
 end
 
+--- Create a test wrapper for a given function.
+---@param f function
+---@param isAsserted boolean If the test function was asserted.
+---@return fun(...:any):boolean, boolean, string test_wrapper The test wrapper which returns the test results.
 local function generateWrapper(f, isAsserted)
   return function(...)
     local ok, ret = f(...)
@@ -160,20 +172,26 @@ for k, v in pairs(Expectations) do
   toInject["EXPECT_" .. k] = generateWrapper(v, false)
   toInject["ASSERT_" .. k] = generateWrapper(v, true)
 end
+
+---@type fun():satisfied:true, error:string Pass the test.
 toInject.PASS = generateWrapper(function() return true, "" end, false)
+---@type fun(reason:string?):satisfied:true, error:string Fail the test, with an optional reason.
 toInject.FAIL = generateWrapper(function(reason) return false, reason or "Forceful failure." end, true)
 
+--- Count the number of tests that are loaded.
+---@return integer tests The total number of tests.
+---@return {suites:table<string,test>} fails The tests that failed, and which suites they are from.
 local function countTests()
   local total = 0
   local fails = {
-    suites = {n = 0}
+    suites = { n = 0 }
   }
   for i = 1, #module.tests do
-    for i, test in ipairs(module.tests[i]) do
+    for j, test in ipairs(module.tests[i]) do
       if test.status == Test.STATUS.FAIL or test.status == Test.STATUS.ERROR then
         total = total + 1
         if not fails.suites[test.suite] then
-          fails.suites[test.suite] = {n = 0}
+          fails.suites[test.suite] = { n = 0 }
           fails.suites.n = fails.suites.n + 1
         end
         fails.suites[test.suite].n = fails.suites[test.suite].n + 1
@@ -207,7 +225,7 @@ local function parseArgs(...)
   for i = 1, args.n do
     local arg = args[i]
     if arg:match("^%-%a") then -- flag, add to flags list
-      for i = 2, #arg do
+      for j = 2, #arg do
         data.flags[arg:sub(i, i):lower()] = true
       end
     elseif arg:match("^%-%-.+") then -- big-flag
@@ -225,6 +243,7 @@ local function setVerbose(v)
   verbose = v
 end
 
+--- Print the disabled tests.
 local function printDisabled()
   if module.disabled > 0 then
     print()
@@ -233,10 +252,12 @@ local function printDisabled()
   end
 end
 
+--- Run all of the tests that have been loaded.
+---@param ... string The arguments to run the tests with.
 function module.runAllTests(...)
-  local args = parseArgs(...)
+  local args         = parseArgs(...)
   local doStackTrace = args.flags.s or args.flags["stack-trace"]
-  verbose      = args.flags.v or args.flags.verbose
+  verbose            = args.flags.v or args.flags.verbose
 
   local startingTerm = term.current()
 
@@ -264,26 +285,31 @@ function module.runAllTests(...)
   local mx, my = term.getSize()
   local c = term.getTextColor()
   term.setTextColor(colors.orange)
-  print(string.format("%d test%s failed from %d suite%s.", total, total > 1 and "s" or "", inSuites.suites.n, inSuites.suites.n > 1 and "s" or ""))
+  print(string.format("%d test%s failed from %d suite%s.", total, total > 1 and "s" or "", inSuites.suites.n,
+    inSuites.suites.n > 1 and "s" or ""))
   term.setTextColor(c)
   for suiteName, tests in pairs(inSuites.suites) do
     if type(tests) == "table" then
       for i = 1, #tests do
         local txt, fg, bg = "Test %s from %s failed.",
-                            "00000%s000000%s00000000",
-                            "fffffffffffffffffff%s"
+            "00000%s000000%s00000000",
+            "fffffffffffffffffff%s"
         local testName = tests[i].name
         txt = txt:format(testName, suiteName)
         fg = fg:format(string.rep('a', #testName), string.rep('b', #suiteName))
         bg = bg:format(string.rep('f', #testName + #suiteName))
         txt = strings.wrap(txt, mx - 2)
-        fg = splitOn(fg, txt)
+
+        ---@diagnostic disable-next-line
+        fg = splitOn(fg, txt) ---@cast fg table
+
+        ---@diagnostic disable-next-line
         bg = splitOn(bg, txt)
 
-        for i = 1, #txt do
+        for j = 1, #txt do
           local x, y = term.getCursorPos()
           term.setCursorPos(3, y)
-          term.blit(txt[i], fg[i], bg[i])
+          term.blit(txt[j], fg[j], bg[j])
           print()
         end
       end
@@ -293,12 +319,17 @@ function module.runAllTests(...)
   printDisabled()
 end
 
+--- Run a single suite of tests.
+---@param s suite The test suite.
+---@param verbose boolean? Whether or not to print verbose text.
+---@param doStackTrace boolean? Whether or not to display a stacktrace on errors.
 function module.runSuite(s, verbose, doStackTrace)
   local fg, bg, txt = "0000000%s",
-                      "fffffff%s",
-                      "Suite: %s"
+      "fffffff%s",
+      "Suite: %s"
   term.blit(txt:format(s.name), fg:format(string.rep('b', #s.name)), bg:format(string.rep('f', #s.name)))
-  print()print()
+  print()
+  print()
   for i = 1, #s do
     local currentTest = s[i]
     local terminated = false
@@ -355,13 +386,17 @@ function module.runSuite(s, verbose, doStackTrace)
   print()
 end
 
+--- Create a new suite.
+---@param suiteName string The name of the suite
 function module.newSuite(suiteName)
-  local suite = {finished = false, name = suiteName}
+  local suite = { finished = false, name = suiteName }
   module.tests[#module.tests + 1] = suite
 
   local currentName, loadBody
 
-  -- Load the name into memory
+  --- Load the name into memory
+  ---@param name string The name of the test to be loaded.
+  ---@return fun(f:{[1]:function}|function)
   local function loadName(name)
     expect(1, name, "string")
     suite.finished = false
@@ -371,7 +406,9 @@ function module.newSuite(suiteName)
     return loadBody
   end
 
-  -- Load the body, then create the test and add it to the suite.
+  --- Load the body, then create the test and add it to the suite.
+  ---@param f {[1]:function}|function The function to test.
+  ---@return fun(name:string)
   loadBody = function(f)
     if type(f) == "table" then
       if f == DISABLED then

--- a/Framework/init.lua
+++ b/Framework/init.lua
@@ -15,8 +15,6 @@ for i = #modulesPath, 1, -1 do
   end
 end
 
----@class test
-
 ---@class suite
 
 local module = {


### PR DESCRIPTION
This PR also introduces some Sumneko documentation. It's not good by any stretch of the word, but honestly this entire repo is kinda a dumpster-fire anyways.

The gist of the breaking change is this:

The signature of the EVENT expectation has changed from:
```lua
function(f:function, event:string, timeout: integer?, ...:any)
```
to
```lua
function(f:function, timeout:integer, event:string, ...:any)
```

This may not look like a small change at a glance, but it also completely redefined how the innards of this expectation works. Instead of calling the given function with `...` as the arguments, it instead will expect that `...` is to be the signature of the returned event. Thus, if you expect your event to be queued as `"some_event", 32, "bruh"` -- those are the values you should insert as `...`. The `event` parameter is also added to this automatically if you didn't do so, it's just split out so as to be able to compare it easier.

I still need to rewrite part of the internal of this function, it should run the event listener and function in parallel.